### PR TITLE
Reduced build warning messages and updated t80 code

### DIFF
--- a/Arcade-DigDug.sv
+++ b/Arcade-DigDug.sv
@@ -303,7 +303,7 @@ FPGA_DIGDUG GameCore (
 	.PH(HPOS),.PV(VPOS),.PCLK(PCLK),.POUT(oPIX),
 	.SOUT(oSND),
 	
-	.ROMCL(clk_sys),.ROMAD(ioctl_addr),.ROMDT(ioctl_dout),.ROMEN(ioctl_wr)
+	.ROMCL(clk_sys),.ROMAD(ioctl_addr[15:0]),.ROMDT(ioctl_dout),.ROMEN(ioctl_wr)
 );
 
 assign POUT = {oPIX[7:6],2'b00,oPIX[5:3],1'b0,oPIX[2:0],1'b0};

--- a/Arcade-DigDug.sv
+++ b/Arcade-DigDug.sv
@@ -110,7 +110,7 @@ wire clk_sys = clk_hdmi;
 
 pll pll
 (
-	.rst(0),
+	.rst(1'b0),
 	.refclk(CLK_50M),
 	.outclk_0(clk_48M),
 	.outclk_1(clk_hdmi)
@@ -334,19 +334,19 @@ assign VPOS = vcnt;
 
 always @(posedge PCLK) begin
 	case (hcnt)
-		288: begin HBLK <= 1; hcnt <= hcnt+1; end
-		311: begin HSYN <= 0; hcnt <= hcnt+1; end
+		288: begin HBLK <= 1; hcnt <= hcnt+1'b1; end
+		311: begin HSYN <= 0; hcnt <= hcnt+1'b1; end
 		342: begin HSYN <= 1; hcnt <= 471;    end
 		511: begin HBLK <= 0; hcnt <= 0;
 			case (vcnt)
-				223: begin VBLK <= 1; vcnt <= vcnt+1; end
-				226: begin VSYN <= 0; vcnt <= vcnt+1; end
+				223: begin VBLK <= 1; vcnt <= vcnt+1'b1; end
+				226: begin VSYN <= 0; vcnt <= vcnt+1'b1; end
 				233: begin VSYN <= 1; vcnt <= 483;	  end
 				511: begin VBLK <= 0; vcnt <= 0;		  end
-				default: vcnt <= vcnt+1;
+				default: vcnt <= vcnt+1'b1;
 			endcase
 		end
-		default: hcnt <= hcnt+1;
+		default: hcnt <= hcnt+1'b1;
 	endcase
 	oRGB <= (HBLK|VBLK) ? 12'h0 : iRGB;
 end

--- a/src/DIGDUG_CORES.v
+++ b/src/DIGDUG_CORES.v
@@ -154,7 +154,7 @@ module CPUARB
 );
 
 reg [1:0] clkdiv;
-always @( posedge CLK48M ) clkdiv <= clkdiv+1;
+always @( posedge CLK48M ) clkdiv <= clkdiv+1'b1;
 wire CLK24M = clkdiv[0];
 wire CLK12M = clkdiv[1];
 
@@ -171,27 +171,27 @@ assign DEV_CL = CLK24M;
 
 assign DEV_AD = BUSS[0] ? CPU0AD :
 					 BUSS[1] ? CPU1AD :
-					 BUSS[2] ? CPU2AD : 0;
+					 BUSS[2] ? CPU2AD : 16'd0000;
 
 assign DEV_RD = BUSS[0] ? CPU0RD :
 					 BUSS[1] ? CPU1RD :
-					 BUSS[2] ? CPU2RD : 0;
+					 BUSS[2] ? CPU2RD : 1'b0;
 
-assign CPU0DV = BUSS[0] ? DEV_DV : 0;
-assign CPU1DV = BUSS[1] ? DEV_DV : 0;
-assign CPU2DV = BUSS[2] ? DEV_DV : 0;
+assign CPU0DV = BUSS[0] ? DEV_DV : 1'b0;
+assign CPU1DV = BUSS[1] ? DEV_DV : 1'b0;
+assign CPU2DV = BUSS[2] ? DEV_DV : 1'b0;
 
-assign CPU0DI = BUSS[0] ? DEV_DO : 0;
-assign CPU1DI = BUSS[1] ? DEV_DO : 0;
-assign CPU2DI = BUSS[2] ? DEV_DO : 0;
+assign CPU0DI = BUSS[0] ? DEV_DO : 8'h00;
+assign CPU1DI = BUSS[1] ? DEV_DO : 8'h00;
+assign CPU2DI = BUSS[2] ? DEV_DO : 8'h00;
 
 assign DEV_WR = BUSS[0] ? CPU0WR :
 					 BUSS[1] ? CPU1WR :
-					 BUSS[2] ? CPU2WR : 0;
+					 BUSS[2] ? CPU2WR : 1'b0;
 
 assign DEV_DI = BUSS[0] ? CPU0DO :
 					 BUSS[1] ? CPU1DO :
-					 BUSS[2] ? CPU2DO : 0;
+					 BUSS[2] ? CPU2DO : 8'h00;
 
 endmodule
 

--- a/src/DIGDUG_CUSIO.v
+++ b/src/DIGDUG_CUSIO.v
@@ -43,9 +43,9 @@ always @( posedge CL ) begin
 		if ( CLK50uc == 2200 ) CLK50u <= 1'b1;
 		if ( CLK50uc == 2400 ) begin
 			CLK50u  <= 1'b0;
-			CLK50uc <= 0;
+			CLK50uc <= 12'h000;
 		end
-		else CLK50uc <= CLK50uc + 1;
+		else CLK50uc <= CLK50uc + 1'b1;
 	end
 end
 
@@ -55,7 +55,7 @@ assign NMI0 = NMI0EN & CLK50u;
 always @( posedge CL or posedge RESET ) begin
 	if (RESET) begin
 		NMI0EN  <= 0;
-		MODE    <= 0;
+		MODE    <= 1'b0;
 		COMMAND <= 0;
 
 		LCINPCRE <= 0;
@@ -69,7 +69,7 @@ always @( posedge CL or posedge RESET ) begin
 			if (AD[4]) begin
 				// command write
 				COMMAND <= DI;
-				MODE    <= (DI==8'hA1) ? 1'b1 : ((DI==8'hC1)|(DI==8'hE1)) ? 0 : MODE;
+				MODE    <= (DI==8'hA1) ? 1'b1 : ((DI==8'hC1)|(DI==8'hE1)) ? 1'b0 : MODE;
 				NMI0EN  <= (DI!=8'h10);
 			end
 			else begin
@@ -140,10 +140,10 @@ wire [15:0] iINP = (pINP^nINP) & nINP;
 
 function [3:0] stick;
 input [3:0] stk;
-	stick =  stk[0] ? 0 :
-			   stk[1] ? 2 :
-			   stk[2] ? 4 :
-			   stk[3] ? 6 : 8;
+	stick =  stk[0] ? 4'h0 :
+			   stk[1] ? 4'h2 :
+			   stk[2] ? 4'h4 :
+			   stk[3] ? 4'h6 : 4'h8;
 endfunction
 
 reg pVBLK = 1'b0;
@@ -179,14 +179,14 @@ always @( posedge CL or posedge RESET ) begin
 			if (CREDITAT) begin
 				if ( LCINPCRE > 0 ) begin
 					if ( iINP[12] & ( CREDITS < 99 ) ) begin
-						LCOINS = LCOINS+1;
+						LCOINS = LCOINS+1'b1;
 						if ( LCOINS >= LCINPCRE ) begin
 							CREDITS = CREDITS + LCREPCIN;
 							LCOINS = 0;
 						end
 					end
 					if ( iINP[13] & ( CREDITS < 99 ) ) begin
-						RCOINS = RCOINS+1;
+						RCOINS = RCOINS+1'b1;
 						if ( RCOINS >= RCINPCRE ) begin
 							CREDITS = CREDITS + RCREPCIN;
 							RCOINS = 0;
@@ -196,8 +196,8 @@ always @( posedge CL or posedge RESET ) begin
 				else CREDITS = 2;
 				if ( CREDITS > 99 ) CREDITS = 99;
 
-				if ( piINP[10] & (CREDITS >= 1) ) CREDITS = CREDITS-1;
-				if ( piINP[11] & (CREDITS >= 2) ) CREDITS = CREDITS-2;
+				if ( piINP[10] & (CREDITS >= 1) ) CREDITS = CREDITS-1'b1;
+				if ( piINP[11] & (CREDITS >= 2) ) CREDITS = CREDITS-2'd2;
 			end
 
 			pINP   <= nINP;

--- a/src/DIGDUG_IODEV.v
+++ b/src/DIGDUG_IODEV.v
@@ -148,13 +148,13 @@ module DIGDUG_CLATCH
 // OSC 120Hz
 `define H120FLOW	(12500)
 reg  [3:0] clkdiv;
-always @( posedge CL ) clkdiv <= clkdiv+1;
+always @( posedge CL ) clkdiv <= clkdiv+1'b1;
 reg [13:0] H120CNT;
 always @( posedge clkdiv[3] or posedge RESET ) begin
 	if (RESET) H120CNT <= 0;
-	else H120CNT <= (H120CNT==`H120FLOW) ? 0 : (H120CNT+1);
+	else H120CNT <= (H120CNT==`H120FLOW) ? 14'd0 : (H120CNT+1'b1);
 end
-wire H120 = ( H120CNT >= (`H120FLOW-200) ) ? 1'b1 : 0;
+wire H120 = ( H120CNT >= (`H120FLOW-200) ) ? 1'b1 : 1'b0;
 
 
 reg IRQ0EN, IRQ0LC;

--- a/src/DIGDUG_IODEV.v
+++ b/src/DIGDUG_IODEV.v
@@ -160,7 +160,7 @@ wire H120 = ( H120CNT >= (`H120FLOW-200) ) ? 1'b1 : 1'b0;
 reg IRQ0EN, IRQ0LC;
 reg IRQ1EN, IRQ1LC;
 reg NMI2EN, NMI2LC;
-reg			NMI0LC;
+//reg			NMI0LC;
 
 reg C12RST = 1'b1;
 reg pH120;
@@ -170,7 +170,7 @@ always @( posedge CL or posedge RESET ) begin
 		IRQ0EN <= 1'b0; IRQ0LC <= 1'b0;
 		IRQ1EN <= 1'b0; IRQ1LC <= 1'b0;
 		NMI2EN <= 1'b0; NMI2LC <= 1'b0;
-		C12RST <= 1'b1; NMI0LC <= 1'b0;
+		C12RST <= 1'b1; //NMI0LC <= 1'b0;
 		pH120  <= 1'b0;
 	end
 	else begin

--- a/src/DIGDUG_SPRITE.v
+++ b/src/DIGDUG_SPRITE.v
@@ -25,8 +25,8 @@ module DIGDUG_SPRITE
 	input				ROMEN
 );
 
-wire [8:0] PH = POSH+1;
-wire [8:0] PV = POSV+2;
+wire [8:0] PH = POSH+1'b1;
+wire [8:0] PV = POSV+2'h2;
 wire [8:0] TY;
 
 
@@ -41,7 +41,7 @@ reg  [8:0] WCN;
 
 
 wire 		  SZ = ATR0[7];													// Size
-wire [8:0] SS = SZ ? 32 : 16;												// Size (Pixels)
+wire [8:0] SS = SZ ? 9'd32 : 9'd16;										// Size (Pixels)
 wire [5:0] SC = ATR1[5:0];													// Color
 wire [8:0] SX = {1'b0,ATR1[15:8]}-9'd39;								// Position X
 wire [8:0] SY = (9'd256-TY);												// Position Y
@@ -52,7 +52,7 @@ wire [7:0] SL = {SM[7]|SM[5],SM[6]|SM[4],SM[3:0],SV[4],SU[4]};	// Code (for Size
 wire [7:0] SN = SZ ? SL : SM;												// Code
 wire		  SD = ATR1[17]|((PV<SY)&(SY<496))|(PV>=(SY+SS));		// Visiblity (False:Visible)
 
-assign TY = ((({1'b0,ATR0[15:8]}+1)+(SZ ? 9'd16 : 9'd0)) & 9'd255) + 9'd30;
+assign TY = ((({1'b0,ATR0[15:8]}+1'b1)+(SZ ? 9'd16 : 9'd0)) & 9'd255) + 9'd30;
 
 wire	ABORT	  = (PH==288);
 wire 	STANDBY = (PH!=289);
@@ -66,35 +66,36 @@ assign SPATAD = ADR[6:0];
 wire [8:0] WSX = {1'b0,SX[7:0]} + ((SX[7:0]<8'd16) ? 9'd256 : 9'd0);
 
 always @( posedge RCLK ) begin
-	if (ABORT) begin PHASE <= 0; WCN <= 0; end
+	if (ABORT) begin PHASE <= 4'd0; WCN <= 9'd0; end
 	else case (PHASE)
 	`define LOOP	(PHASE)
-	`define NEXT	(PHASE+1)
-	`define NXTA	(1)
-		0: begin SIDE <= PV[0]; ADR <= 0; WCN <= 0; 	PHASE <= STANDBY ? `LOOP :	`NEXT; end
+	`define NEXT	(PHASE+1'b1)
+	`define NXTA	(4'd1)
+		0: begin SIDE <= PV[0]; ADR <= 8'd0; WCN <= 9'd0; 	PHASE <= STANDBY ? `LOOP :	`NEXT; end
 		1: begin 												PHASE <= ATRTAIL ? `NXTA : `NEXT; end
-		2: begin ATR0 <= SPATDT; ADR <= ADR+1;			PHASE <= 						`NEXT; end
-		3: begin ATR1 <= SPATDT; ADR <= ADR+1;			PHASE <= 			         `NEXT; end
+		2: begin ATR0 <= SPATDT; ADR <= ADR+1'b1;		PHASE <= 						`NEXT; end
+		3: begin ATR1 <= SPATDT; ADR <= ADR+1'b1;		PHASE <= 			         `NEXT; end
 		4: begin WXP  <= WSX;	 WCN <= SS;				PHASE <=      SD ? `NXTA :	`NEXT; end
 					// CHIP Read 
 		5: begin /* CLUT Read */ 							PHASE <= 						`NEXT; end
 					// LBUF Write
-		6: begin WXP <= WXP+1; WCN <= WCN-1;			PHASE <= DRAWING ?     5 :	`NXTA; end
+		6: begin WXP <= WXP+1'b1; WCN <= WCN-1'b1;	PHASE <= DRAWING ?  4'd5 :	`NXTA; end
 		default:;
 	endcase
 end
 
 wire [7:0] CHRD;
-DLROMe #(14,8) spchip((PHASE==5),~RCLK,{SN,SV[3],SU[3:2],SV[2:0]},CHRD, ROMCL,ROMAD[14:0],ROMDT,ROMEN & (ROMAD[15:14]==2'b01));
+DLROMe #(14,8) spchip((PHASE==4'd5),~RCLK,{SN,SV[3],SU[3:2],SV[2:0]},CHRD, ROMCL,ROMAD[13:0],ROMDT,ROMEN & (ROMAD[15:14]==2'b01));
 wire [7:0] PIX = CHRD << (SU[1:0]);
 
 wire [7:0] WDT;
-DLROMe #(8,8)  spclut((PHASE==5), RCLK,{SC,PIX[7],PIX[3]},WDT, ROMCL,ROMAD[7:0],ROMDT,ROMEN & (ROMAD[15:8]==8'hD9));
+DLROMe #(8,8)  spclut((PHASE==4'd5), RCLK,{SC,PIX[7],PIX[3]},WDT, ROMCL,ROMAD[7:0],ROMDT,ROMEN & (ROMAD[15:8]==8'hD9));
 
 wire [4:0] LBOUT;
+wire [2:0] unused;
 LBUF1K lbuf (
-	  ~RCLK, {SIDE,WXP}, (PHASE==6) & (PIX[7]|PIX[3]), {4'h1,WDT[3:0]},
-	 VCLKx2, {~SIDE,PH}, (radr0==radr1), 8'h0, LBOUT
+	  ~RCLK, {SIDE,WXP}, (PHASE==4'd6) & (PIX[7]|PIX[3]), {4'h1,WDT[3:0]},
+	 VCLKx2, {~SIDE,PH}, (radr0==radr1), 8'h0, {unused, LBOUT}
 );
 
 reg [9:0] radr0=0,radr1=1;

--- a/src/DIGDUG_VIDEO.v
+++ b/src/DIGDUG_VIDEO.v
@@ -39,7 +39,7 @@ module DIGDUG_VIDEO
 reg [2:0] clkdiv;
 always @( posedge CLK48M ) clkdiv <= clkdiv+1'b1;
 wire VCLKx8 = CLK48M;
-wire VCLKx4 = clkdiv[0];
+//wire VCLKx4 = clkdiv[0];
 wire VCLKx2 = clkdiv[1];
 wire VCLK   = clkdiv[2];
 

--- a/src/DIGDUG_VIDEO.v
+++ b/src/DIGDUG_VIDEO.v
@@ -37,7 +37,7 @@ module DIGDUG_VIDEO
 //  Clock Generator
 //---------------------------------------
 reg [2:0] clkdiv;
-always @( posedge CLK48M ) clkdiv <= clkdiv+1;
+always @( posedge CLK48M ) clkdiv <= clkdiv+1'b1;
 wire VCLKx8 = CLK48M;
 wire VCLKx4 = clkdiv[0];
 wire VCLKx2 = clkdiv[1];
@@ -49,7 +49,7 @@ wire VCLK   = clkdiv[2];
 //---------------------------------------
 reg [8:0] PH, PV;
 always@( posedge VCLK ) begin
-	PH <= POSH+1;
+	PH <= POSH+1'b1;
 	PV <= POSV+(POSH>=504);
 end
 
@@ -57,8 +57,8 @@ end
 //---------------------------------------
 //  VRAM Scan Address Generator
 //---------------------------------------
-wire  [5:0] SCOL = PH[8:3]-2;
-wire  [5:0] SROW = PV[8:3]+2;
+wire  [5:0] SCOL = PH[8:3]-2'd2;
+wire  [5:0] SROW = PV[8:3]+2'd2;
 wire  [9:0] VSAD = SCOL[5] ? {SCOL[4:0],SROW[4:0]} : {SROW[4:0],SCOL[4:0]};
 
 
@@ -70,7 +70,7 @@ wire  [4:0]	SPCOL;
 DIGDUG_SPRITE sprite
 (
 	.RCLK(VCLKx8),.VCLK(VCLK),.VCLKx2(VCLKx2),
-	.POSH(PH-1),.POSV(PV),
+	.POSH(PH-1'b1),.POSV(PV),
 	.SPATCL(SPATCL),.SPATAD(SPATAD),.SPATDT(SPATDT),
 
 	.SPCOL(SPCOL),
@@ -123,7 +123,7 @@ wire [4:0] CMIX = SPCOL[4] ? {1'b1,SPCOL[3:0]} : FGCOL[4] ? {1'b0,FGCOL[3:0]} : 
 
 DLROM #(5,8) palet( VCLK, CMIX, POUT, ROMCL,ROMAD[4:0],ROMDT,ROMEN & (ROMAD[15:5]=={8'hDB,3'b000}) );
 assign PCLK = ~VCLK;
-assign VBLK = (PH<64)&(PV==224);
+assign VBLK = (PH<9'd64)&(PV==9'd224);
 
 endmodule
 

--- a/src/DIGDUG_VIDEO.v
+++ b/src/DIGDUG_VIDEO.v
@@ -113,7 +113,7 @@ wire  [7:0] BGCHPI = BGCHDT << (PH[1:0]);
 wire  [1:0] BGCHPX = {BGCHPI[7],BGCHPI[3]};
 
 wire  [7:0] BGCLAD = BG_CUTOFF ? {6'h0F,BGCHPX} : {BG_COLBNK,BGSCDT[7:4],BGCHPX};
-DLROM #(8,4) bgclut(VCLKx2,BGCLAD,BGCOL, ROMCL,ROMAD[7:0],ROMDT,ROMEN & (ROMAD[15:8]==8'hDA));
+DLROM #(8,4) bgclut(VCLKx2,BGCLAD,BGCOL, ROMCL,ROMAD[7:0],ROMDT[3:0],ROMEN & (ROMAD[15:8]==8'hDA));
 
 
 //---------------------------------------

--- a/src/FPGA_DIGDUG.v
+++ b/src/FPGA_DIGDUG.v
@@ -66,7 +66,7 @@ wire 			WAVECL;
 wire [7:0]	WAVEAD;
 wire [3:0]	WAVEDT;
 
-DLROM #(8,4) wave(WAVECL,WAVEAD,WAVEDT, ROMCL,ROMAD[7:0],ROMDT,ROMEN & (ROMAD[15:8]==8'hD8));
+DLROM #(8,4) wave(WAVECL,WAVEAD,WAVEDT, ROMCL,ROMAD[7:0],ROMDT[3:0],ROMEN & (ROMAD[15:8]==8'hD8));
 
 
 //-----------------------------------------------

--- a/src/cpu/tv80_alu.v
+++ b/src/cpu/tv80_alu.v
@@ -231,13 +231,13 @@ module tv80_alu (/*AUTOARG*/
                       begin
 			F_Out[Flag_H] = 1'b0;
 		      end
-		    DAA_Q = DAA_Q + 6;
+		    DAA_Q = DAA_Q + 9'd6;
 		  end // if (DAA_Q[3:0] > 9 || F_In[Flag_H] == 1'b1 )
                 
 		// new Ahigh > 9 || C == 1
 		if (DAA_Q[8:4] > 9 || F_In[Flag_C] == 1'b1 ) 
                   begin
-		    DAA_Q = DAA_Q + 96; // 0x60
+		    DAA_Q = DAA_Q + 9'd96; // 0x60
 		  end
 	      end 
             else 
@@ -249,11 +249,11 @@ module tv80_alu (/*AUTOARG*/
                       begin
 			F_Out[Flag_H] = 1'b0;
 		      end
-		    DAA_Q[7:0] = DAA_Q[7:0] - 6;
+		    DAA_Q[7:0] = DAA_Q[7:0] - 8'd6;
 		  end
 		if (BusA > 153 || F_In[Flag_C] == 1'b1 ) 
                   begin
-		    DAA_Q = DAA_Q - 352; // 0x160
+		    DAA_Q = DAA_Q - 9'd352; // 0x160
 		  end
 	      end // else: !if(F_In[Flag_N] == 1'b0 )
             

--- a/src/cpu/tv80_alu.v
+++ b/src/cpu/tv80_alu.v
@@ -58,7 +58,7 @@ module tv80_alu (/*AUTOARG*/
     input Sub;
     input Carry_In;
     begin
-      AddSub4 = { 1'b0, A } + { 1'b0, (Sub)?~B:B } + Carry_In;
+      AddSub4 = { 1'b0, A } + { 1'b0, (Sub)?~B:B } + {4'h0,Carry_In};
     end
   endfunction // AddSub4
   
@@ -68,7 +68,7 @@ module tv80_alu (/*AUTOARG*/
     input Sub;
     input Carry_In;
     begin
-      AddSub3 = { 1'b0, A } + { 1'b0, (Sub)?~B:B } + Carry_In;
+      AddSub3 = { 1'b0, A } + { 1'b0, (Sub)?~B:B } + {3'h0,Carry_In};
     end
   endfunction // AddSub4
 
@@ -78,7 +78,7 @@ module tv80_alu (/*AUTOARG*/
     input Sub;
     input Carry_In;
     begin
-      AddSub1 = { 1'b0, A } + { 1'b0, (Sub)?~B:B } + Carry_In;
+      AddSub1 = { 1'b0, A } + { 1'b0, (Sub)?~B:B } + {1'h0,Carry_In};
     end
   endfunction // AddSub4
 

--- a/src/cpu/tv80_core.v
+++ b/src/cpu/tv80_core.v
@@ -592,7 +592,7 @@ module tv80_core (/*AUTOARG*/
                                 begin
                                   if (Inc_WZ == 1'b1 )
                                     begin
-                                      A <= #1 TmpAddr + 1;
+                                      A <= #1 TmpAddr + 1'b1;
                                     end
                                   else
                                     begin
@@ -1303,11 +1303,11 @@ module tv80_core (/*AUTOARG*/
         end
       else if (BTR_r == 1'b1 )
         begin
-          PC16_B = -2;
+          PC16_B = -16'd2;
         end
       else
         begin
-          PC16_B = 1;
+          PC16_B = 16'd1;
         end
 
       if (tstate[3])
@@ -1321,15 +1321,15 @@ module tv80_core (/*AUTOARG*/
           SP16_A = SP;
 
           if (IncDec_16[3] == 1'b1)
-            SP16_B = -1;
+            SP16_B = -16'd1;
           else
-            SP16_B = 1;
+            SP16_B = 16'd1;
         end
 
       if (IncDec_16[3])
-        ID16_B = -1;
+        ID16_B = -16'd1;
       else
-        ID16_B = 1;
+        ID16_B = 16'd1;
 
       ID16 = RegBusA + ID16_B;
       PC16 = PC + PC16_B;

--- a/src/cpu/tv80_mcode.v
+++ b/src/cpu/tv80_mcode.v
@@ -2,7 +2,7 @@
 // TV80 8-Bit Microprocessor Core
 // Based on the VHDL T80 core by Daniel Wallner (jesus@opencores.org)
 //
-// Copyright (c) 2004 Guy Hutchison (ghutchis@opencores.org)
+// Copyright (c) 2004,2007 Guy Hutchison (ghutchis@opencores.org)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a 
 // copy of this software and associated documentation files (the "Software"), 
@@ -162,16 +162,16 @@ module tv80_mcode
   //    constant aZI    : std_logic_vector[2:0] = 3'b110;
 
   function is_cc_true;
-    input [7:0] F;
+    input [7:0] FF;
     input [2:0] cc;
     begin
       if (Mode == 3 ) 
         begin
           case (cc)
-            3'b000  : is_cc_true = F[7] == 1'b0; // NZ
-            3'b001  : is_cc_true = F[7] == 1'b1; // Z
-            3'b010  : is_cc_true = F[4] == 1'b0; // NC
-            3'b011  : is_cc_true = F[4] == 1'b1; // C
+            3'b000  : is_cc_true = FF[7] == 1'b0; // NZ
+            3'b001  : is_cc_true = FF[7] == 1'b1; // Z
+            3'b010  : is_cc_true = FF[4] == 1'b0; // NC
+            3'b011  : is_cc_true = FF[4] == 1'b1; // C
             3'b100  : is_cc_true = 0;
             3'b101  : is_cc_true = 0;
             3'b110  : is_cc_true = 0;
@@ -181,14 +181,14 @@ module tv80_mcode
       else 
         begin
           case (cc)
-            3'b000  : is_cc_true = F[6] == 1'b0; // NZ
-            3'b001  : is_cc_true = F[6] == 1'b1; // Z
-            3'b010  : is_cc_true = F[0] == 1'b0; // NC
-            3'b011  : is_cc_true = F[0] == 1'b1; // C
-            3'b100  : is_cc_true = F[2] == 1'b0; // PO
-            3'b101  : is_cc_true = F[2] == 1'b1; // PE
-            3'b110  : is_cc_true = F[7] == 1'b0; // P
-            3'b111  : is_cc_true = F[7] == 1'b1; // M
+            3'b000  : is_cc_true = FF[6] == 1'b0; // NZ
+            3'b001  : is_cc_true = FF[6] == 1'b1; // Z
+            3'b010  : is_cc_true = FF[0] == 1'b0; // NC
+            3'b011  : is_cc_true = FF[0] == 1'b1; // C
+            3'b100  : is_cc_true = FF[2] == 1'b0; // PO
+            3'b101  : is_cc_true = FF[2] == 1'b1; // PE
+            3'b110  : is_cc_true = FF[7] == 1'b0; // P
+            3'b111  : is_cc_true = FF[7] == 1'b1; // M
           endcase
         end
     end
@@ -270,9 +270,9 @@ module tv80_mcode
             //
             //----------------------------------------------------------------------------
 
-            casex (IR)
+            casez (IR)
               // 8 BIT LOAD GROUP
-              8'b01xxxxxx :
+              8'b01zzzzzz :
                 begin
                   if (IR[5:0] == 6'b110110)
                     Halt = 1'b1;
@@ -308,9 +308,9 @@ module tv80_mcode
                       Set_BusA_To[2:0] = DDD;
                       Read_To_Reg = 1'b1;
                     end // else: !if(IR[5:3] == 3'b110)
-                end // case: 8'b01xxxxxx                                    
+                end // case: 8'b01zzzzzz                                    
 
-              8'b00xxx110 :
+              8'b00zzz110 :
                 begin
                   if (IR[5:3] == 3'b110)
                     begin
@@ -623,7 +623,7 @@ module tv80_mcode
                   LDSPHL = 1'b1;
                 end
               
-              8'b11xx0101 :
+              8'b11zz0101 :
                 begin
                   // PUSH qq
                   MCycles = 3'b011;
@@ -668,7 +668,7 @@ module tv80_mcode
                   endcase // case(MCycle)
                 end // case: 8'b11000101,8'b11010101,8'b11100101,8'b11110101
               
-              8'b11xx0001 :
+              8'b11zz0001 :
                 begin
                   // POP qq
                   MCycles = 3'b011;
@@ -839,7 +839,7 @@ module tv80_mcode
               
 
               // 8 BIT ARITHMETIC AND LOGICAL GROUP
-              8'b10xxxxxx :
+              8'b10zzzzzz :
                 begin
                   if (IR[2:0] == 3'b110)
                     begin
@@ -883,7 +883,7 @@ module tv80_mcode
                     end // else: !if(IR[2:0] == 3'b110)                  
                 end // case: 8'b10000000,8'b10000001,8'b10000010,8'b10000011,8'b10000100,8'b10000101,8'b10000111,...
               
-              8'b11xxx110 :
+              8'b11zzz110 :
                 begin
                   // ADD A,n
                   // ADC A,n
@@ -904,7 +904,7 @@ module tv80_mcode
                     end
                 end
               
-              8'b00xxx100 :
+              8'b00zzz100 :
                 begin
                   if (IR[5:3] == 3'b110)
                     begin
@@ -942,7 +942,7 @@ module tv80_mcode
                     end
                 end
               
-              8'b00xxx101 :
+              8'b00zzz101 :
                 begin               
                   if (IR[5:3] == 3'b110)
                     begin
@@ -1087,7 +1087,7 @@ module tv80_mcode
                 SetEI = 1'b1;
 
               // 16 BIT ARITHMETIC GROUP
-              8'b00001001,8'b00011001,8'b00101001,8'b00111001  :
+              8'b00zz1001  :
                 begin
                   // ADD HL,ss
                   MCycles = 3'b011;
@@ -1134,7 +1134,7 @@ module tv80_mcode
                   endcase // case(MCycle)
                 end // case: 8'b00001001,8'b00011001,8'b00101001,8'b00111001              
               
-              8'b00000011,8'b00010011,8'b00100011,8'b00110011  :
+              8'b00zz0011 :
                 begin
                   // INC ss
                   TStates = 3'b110;
@@ -1142,7 +1142,7 @@ module tv80_mcode
                   IncDec_16[1:0] = DPAIR;
                 end
               
-              8'b00001011,8'b00011011,8'b00101011,8'b00111011  :
+              8'b00zz1011 :
                 begin
                   // DEC ss
                   TStates = 3'b110;
@@ -1186,7 +1186,7 @@ module tv80_mcode
                   
                 end // case: 8'b11000011
               
-              8'b11xxx010  :
+              8'b11zzz010  :
                 begin
                   if (IR[5] == 1'b1 && Mode == 3 ) 
                     begin
@@ -1318,7 +1318,7 @@ module tv80_mcode
                 end // case: 8'b00011000
 
               // Conditional relative jumps (JR [C/NC/Z/NZ], e)
-              8'b001xx000  :
+              8'b001zz000  :
                 begin
                   if (Mode != 2 ) 
                     begin
@@ -1425,7 +1425,7 @@ module tv80_mcode
                   endcase // case(MCycle)
                 end // case: 8'b11001101
               
-              8'b11000100,8'b11001100,8'b11010100,8'b11011100,8'b11100100,8'b11101100,8'b11110100,8'b11111100  :
+              8'b11zzz100  :
                 begin
                   if (IR[5] == 1'b0 || Mode != 3 ) 
                     begin
@@ -1643,7 +1643,7 @@ module tv80_mcode
                     end // else: !if(IR[5] == 1'b1 && Mode == 3 )
                 end // case: 8'b11000000,8'b11001000,8'b11010000,8'b11011000,8'b11100000,8'b11101000,8'b11110000,8'b11111000
               
-              8'b11000111,8'b11001111,8'b11010111,8'b11011111,8'b11100111,8'b11101111,8'b11110111,8'b11111111  :
+              8'b11zz0111,8'b11zz1111  :
                 begin
                   // RST p
                   MCycles = 3'b011;
@@ -1772,7 +1772,7 @@ module tv80_mcode
             Set_BusA_To[2:0] = IR[2:0];
             Set_BusB_To[2:0] = IR[2:0];
             
-            case (IR)
+            casez (IR)
               8'b00000000,8'b00000001,8'b00000010,8'b00000011,8'b00000100,8'b00000101,8'b00000111,
               8'b00010000,8'b00010001,8'b00010010,8'b00010011,8'b00010100,8'b00010101,8'b00010111,
               8'b00001000,8'b00001001,8'b00001010,8'b00001011,8'b00001100,8'b00001101,8'b00001111,
@@ -1797,8 +1797,7 @@ module tv80_mcode
                   end
                 end // case: 8'b00000000,8'b00000001,8'b00000010,8'b00000011,8'b00000100,8'b00000101,8'b00000111,...
               
-              8'b00000110, 8'b00001110, 8'b00010110, 8'b00011110,
-              8'b00100110, 8'b00101110, 8'b00110110, 8'b00111110 :
+              8'b00zzz110  :
                 begin
                   // RLC (HL)
                   // RL (HL)
@@ -1953,7 +1952,7 @@ module tv80_mcode
             //
             //----------------------------------------------------------------------------
 
-            case (IR)
+            casez (IR)
 	      /*
 	       * Undocumented NOP instructions commented out to reduce size of mcode
 	       *
@@ -2576,6 +2575,8 @@ module tv80_mcode
                   endcase // case(MCycle)
                 end // case: 8'b10100011 , 8'b10101011 , 8'b10110011 , 8'b10111011
               
+              default : ;
+
             endcase // case(IR)                  
           end // block: default_ed_block        
       endcase // case(ISet)
@@ -2646,8 +2647,4 @@ module tv80_mcode
         end // if (Mode < 2 )      
       
     end // always @ (IR, ISet, MCycle, F, NMICycle, IntCycle)
-  
-  // synopsys dc_script_begin
-  // set_attribute current_design "revision" "$Id: tv80_mcode.v,v 1.6 2005/12/13 19:17:09 ghutchis Exp $" -type string -quiet
-  // synopsys dc_script_end
 endmodule // T80_MCode

--- a/src/cpu/tv80_reg.v
+++ b/src/cpu/tv80_reg.v
@@ -41,8 +41,8 @@ module tv80_reg (/*AUTOARG*/
     output [7:0] DOAH;
     input  clk, CEN, WEH, WEL;
 
-  reg [7:0] RegsH [0:7];
-  reg [7:0] RegsL [0:7];
+  (* ramstyle = "no_rw_check" *) reg [7:0] RegsH [0:7];
+  (* ramstyle = "no_rw_check" *) reg [7:0] RegsL [0:7];
 
   always @(posedge clk)
     begin
@@ -61,11 +61,16 @@ module tv80_reg (/*AUTOARG*/
   assign DOCL = RegsL[AddrC];
 
   // break out ram bits for waveform debug
+// synopsys translate_off
+  wire [7:0] B = RegsH[0];
+  wire [7:0] C = RegsL[0];
+  wire [7:0] D = RegsH[1];
+  wire [7:0] E = RegsL[1];
   wire [7:0] H = RegsH[2];
   wire [7:0] L = RegsL[2];
   
-// synopsys dc_script_begin
-// set_attribute current_design "revision" "$Id: tv80_reg.v,v 1.1 2004/05/16 17:39:57 ghutchis Exp $" -type string -quiet
-// synopsys dc_script_end
+  wire [15:0] IX = { RegsH[3], RegsL[3] };
+  wire [15:0] IY = { RegsH[7], RegsL[7] };
+// synopsys translate_on
+ 
 endmodule
-

--- a/src/cpu/tv80s.v
+++ b/src/cpu/tv80s.v
@@ -26,7 +26,7 @@
 
 module tv80s (/*AUTOARG*/
   // Outputs
-  m1_n, mreq_n, iorq_n, rd_n, wr_n, rfsh_n, halt_n, busak_n, A, do,
+  m1_n, mreq_n, iorq_n, rd_n, wr_n, rfsh_n, halt_n, busak_n, A, dout,
   // Inputs
   reset_n, clk, wait_n, int_n, nmi_n, busrq_n, di
   );
@@ -52,7 +52,7 @@ module tv80s (/*AUTOARG*/
   output        busak_n;
   output [15:0] A;
   input [7:0]   di;
-  output [7:0]  do;
+  output [7:0]  dout;
 
   reg           mreq_n;
   reg           iorq_n;
@@ -91,13 +91,13 @@ module tv80s (/*AUTOARG*/
      .A (A),
      .dinst (di),
      .di (di_reg),
-     .do (do),
+     .dout (dout),
      .mc (mcycle),
      .ts (tstate),
      .intcycle_n (intcycle_n)
      );
 
-  always @(posedge clk)
+  always @(posedge clk or negedge reset_n)
     begin
       if (!reset_n)
         begin
@@ -161,4 +161,3 @@ module tv80s (/*AUTOARG*/
     end // always @ (posedge clk or negedge reset_n)
 
 endmodule // t80s
-

--- a/src/cpucore.v
+++ b/src/cpucore.v
@@ -35,7 +35,7 @@ tv80s core(
 	.rd_n(m_rd),
 	.wr_n(m_wr),
 	.A(m_ad),
-	.do(m_do),
+	.dout(m_do),
 
 	.reset_n(~RESET),
 	.clk(CLK),

--- a/src/dprams.v
+++ b/src/dprams.v
@@ -42,7 +42,7 @@ module DPR2K
 	output reg [7:0]	DO1
 );
 
-reg [7:0] core[0:2047];
+reg [7:0] core[0:2047] /* synthesis ramstyle = "no_rw_check, M10K" */;
 
 always @( posedge CL0 ) begin
 	if (EN0) begin
@@ -100,7 +100,7 @@ module DLROM #(parameter AW,parameter DW)
 	input							WE1
 );
 
-reg [DW:0] core[0:((2**AW)-1)];
+reg [DW-1:0] core[0:((2**AW)-1)] /* synthesis ramstyle = "no_rw_check, M10K" */;
 
 always @(posedge CL0) DO0 <= core[AD0];
 always @(posedge CL1) if (WE1) core[AD1] <= DI1;
@@ -121,7 +121,7 @@ module DLROMe #(parameter AW,parameter DW)
 	input							WE1
 );
 
-reg [DW:0] core[0:((2**AW)-1)];
+reg [DW-1:0] core[0:((2**AW)-1)] /* synthesis ramstyle = "no_rw_check, M10K" */;
 
 always @(posedge CL0) if (RE0) DO0 <= core[AD0];
 always @(posedge CL1) if (WE1) core[AD1] <= DI1;

--- a/src/wsg.v
+++ b/src/wsg.v
@@ -171,44 +171,44 @@ reg   [1:0] phase;
 always @ ( posedge WSGCLKx4 or posedge RESET ) begin
 
    if ( RESET ) begin
-      phase  <= 0;
-      sndout <= 0;
-		outclk <= 0;
-		cc1    <= 0;
-		cc2    <= 0;
+      phase  <= 2'h0;
+      sndout <= 8'h00;
+		outclk <= 1'b0;
+		cc1    <= 8'h00;
+		cc2    <= 8'h00;
    end
    else begin
 
       case ( phase )
 
-      0: begin
+      2'h0: begin
             sndout  <= ( sndmixdown[9:2] | {8{sndmixdown[10]}} );
 
 				cc1     <= {W1,c1[15:11]};
 				cc2     <= {W2,c2[15:11]};
 
-            sndmix  <= 0;
+            sndmix  <= 10'h000;
             waveadr <= {W0,c0[19:15]};
-            wavevol <= (F0!=0) ? V0 : 0;
+            wavevol <= (F0!=0) ? V0 : 4'h0;
          end
 
-      1: begin
+      2'h1: begin
 				outclk  <= 1'b1;
             sndmix  <= sndmix + waveout;
 
             waveadr <= cc1;
-            wavevol <= (F1!=0) ? V1 : 0;
+            wavevol <= (F1!=0) ? V1 : 4'h0;
          end
 
-      2: begin
+      2'h2: begin
             sndmix  <= sndmix + waveout;
 
             waveadr <= cc2;
-            wavevol <= (F2!=0) ? V2 : 0;
+            wavevol <= (F2!=0) ? V2 : 4'h0;
          end
 
-      3: begin
-				outclk  <= 0;
+      2'h3: begin
+				outclk  <= 1'b0;
             sndmix  <= sndmix + waveout;
          end
 
@@ -216,7 +216,7 @@ always @ ( posedge WSGCLKx4 or posedge RESET ) begin
 
       endcase
 
-      phase <= phase+1;
+      phase <= phase+1'b1;
 
       c0 <= c0 + F0;
       c1 <= c1 + F1;

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -534,7 +534,7 @@ ascal
 	.vmin     (vmin),
 	.vmax     (vmax),
 
-	.mode     ({~lowlat,FB_EN ? FB_FLT : |scaler_flt,2'b00}),
+	.mode     ({1'b0,~lowlat,FB_EN ? FB_FLT : |scaler_flt,2'b00}),
 	.poly_clk (clk_sys),
 	.poly_a   (coef_addr),
 	.poly_dw  (coef_data),

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -711,7 +711,7 @@ pll_cfg pll_cfg
 	.mgmt_clk(FPGA_CLK1_50),
 	.mgmt_reset(reset_req),
 	.mgmt_waitrequest(cfg_waitrequest),
-	.mgmt_read(0),
+	.mgmt_read(1'b0),
 	.mgmt_readdata(),
 	.mgmt_write(cfg_write),
 	.mgmt_address(cfg_address),
@@ -720,34 +720,34 @@ pll_cfg pll_cfg
 	.reconfig_from_pll(reconfig_from_pll)
 );
 
-reg cfg_ready = 0;
+reg cfg_ready = 1'b0;
 
 always @(posedge FPGA_CLK1_50) begin
-	reg gotd = 0, gotd2 = 0;
-	reg custd = 0, custd2 = 0;
-	reg old_wait = 0;
+	reg gotd = 1'b0, gotd2 = 1'b0;
+	reg custd = 1'b0, custd2 = 1'b0;
+	reg old_wait = 1'b0;
 
 	gotd  <= cfg_got;
 	gotd2 <= gotd;
 	
-	adj_write <= 0;
+	adj_write <= 1'b0;
 	
 	custd <= cfg_custom_t;
 	custd2 <= custd;
 	if(custd2 != custd & ~gotd) begin
 		adj_address <= cfg_custom_p1;
 		adj_data <= cfg_custom_p2;
-		adj_write <= 1;
+		adj_write <= 1'b1;
 	end
 
 	if(~gotd2 & gotd) begin
-		adj_address <= 2;
-		adj_data <= 0;
-		adj_write <= 1;
+		adj_address <= 6'd2;
+		adj_data <= 32'd0;
+		adj_write <= 1'b1;
 	end
 
 	old_wait <= adj_waitrequest;
-	if(old_wait & ~adj_waitrequest & gotd) cfg_ready <= 1;
+	if(old_wait & ~adj_waitrequest & gotd) cfg_ready <= 1'b1;
 end
 
 wire hdmi_config_done;
@@ -824,10 +824,10 @@ always @(posedge clk_vid) begin
 			old_vs <= vga_vs_osd;
 			if(~&vcnt) vcnt <= vcnt + 1'd1;
 			if(~old_vs & vga_vs_osd & ~f1) vsz <= vcnt;
-			if(old_vs & ~vga_vs_osd) vcnt <= 0;
+			if(old_vs & ~vga_vs_osd) vcnt <= 13'd0;
 			
-			if(vcnt == 1) vde <= 1;
-			if(vcnt == vsz - 3) vde <= 0;
+			if(vcnt == 13'd1) vde <= 1'b1;
+			if(vcnt == vsz - 2'd3) vde <= 1'b0;
 		end
 
 		dv_de1 <= !{hss,vga_hs_osd} && vde;
@@ -953,7 +953,7 @@ csync csync_vga(clk_vid, vga_hs_osd, vga_vs_osd, vga_cs_osd);
 	wire [23:0] vga_o;
 	vga_out vga_out
 	(
-		.ypbpr_full(0),
+		.ypbpr_full(1'b0),
 		.ypbpr_en(ypbpr_en),
 		.dout(vga_o),
 		.din(vga_scaler ? {24{hdmi_de_osd}} & hdmi_data_osd : vga_data_osd)


### PR DESCRIPTION
This patch set eliminates a number of build warning messages (mostly related to truncation of signals) and fixes a bug in the t80 core.  The t80 fix was also caught in the latest OpenCores version of the t80 core so I pulled in the other updates from there as well (mostly just code clean up).  Hopefully this is helpful.
